### PR TITLE
Feature/issue 146 add benchmark to tox

### DIFF
--- a/docs/scbenchmarker/setup.py
+++ b/docs/scbenchmarker/setup.py
@@ -25,6 +25,6 @@ setup(
     install_requires=[
         "memory_profiler",
         "jinja2",
-        f'sqlitecollections @ file://{root_dir}',
+        f'sqlitecollections[docs] @ file://{root_dir}',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -38,3 +38,9 @@ deps = -e .[docs]
 commands =
     mkdocs build
     mkdocs gh-deploy
+
+[testenv:py{36,37,38,39,310}-benchmark]
+deps =
+    -e ./docs/scbenchmarker
+commands =
+    python -m scbenchmarker --prefix={posargs:{envname}}


### PR DESCRIPTION
closes #146.

In this implementation, we need to enter explicit envname like `tox -e py36-benchmark py36`.
The following one-liner runs all the benchmarks on all supported python versoins:
```
for ee in py36 py37 py38 py39 py310; do tox -e ${ee}-benchmark ${ee}; done
```

Further improvements are expected.