### PR TITLE
refactor(set): improve lt and le efficiency

### DIFF
--- a/sqlitecollections/dict.py
+++ b/sqlitecollections/dict.py
@@ -433,10 +433,12 @@ if sys.version_info >= (3, 9):
             self.update(other)
             return self
 
+
 elif sys.version_info >= (3, 8):
 
     class Dict(_ReversibleDict[KT, VT]):
         ...
+
 
 else:
 

--- a/sqlitecollections/dict.py
+++ b/sqlitecollections/dict.py
@@ -433,12 +433,10 @@ if sys.version_info >= (3, 9):
             self.update(other)
             return self
 
-
 elif sys.version_info >= (3, 8):
 
     class Dict(_ReversibleDict[KT, VT]):
         ...
-
 
 else:
 

--- a/sqlitecollections/set.py
+++ b/sqlitecollections/set.py
@@ -240,13 +240,19 @@ class Set(SqliteCollectionBase[T], MutableSet[T]):
     def issubset(self, other: Iterable[T]) -> bool:
         return len(self) == len(self.intersection(other))
 
-    def __lt__(self, other: Iterable[T]) -> bool:
-        return self._driver_class.is_proper_subset(
-            self.table_name, self.connection.cursor(), self.connection.cursor(), (self.serialize(d) for d in other)
-        )
+    def __lt__(self, other: AbstractSet[T]) -> bool:
+        if len(self) >= len(other):
+            return False
+        for d in self:
+            if d not in other:
+                return False
+        return True
 
-    def __le__(self, other: Iterable[T]) -> bool:
-        return self.issubset(other)
+    def __le__(self, other: AbstractSet[T]) -> bool:
+        for d in self:
+            if d not in other:
+                return False
+        return True
 
     def intersection(self, *others: Iterable[T]) -> "Set[T]":
         res = self.copy()
@@ -266,12 +272,12 @@ class Set(SqliteCollectionBase[T], MutableSet[T]):
                 return False
         return True
 
-    def __gt__(self, other: Iterable[T]) -> bool:
+    def __gt__(self, other: AbstractSet[T]) -> bool:
         return self._driver_class.is_proper_superset(
             self.table_name, self.connection.cursor(), self.connection.cursor(), (self.serialize(d) for d in other)
         )
 
-    def __ge__(self, other: Iterable[T]) -> bool:
+    def __ge__(self, other: AbstractSet[T]) -> bool:
         return self.issuperset(other)
 
     def union(self, *others: Iterable[T]) -> "Set[T]":


### PR DESCRIPTION
closes #140 #139 

also, the efficiencies of `__le__` and `__lt__` are improved.

## before

{'subject': '`__le__`', 'one': {'name': '`set`', 'timing': 0.0017616599798202515, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 3.3105702102184296, 'memory': 0.9296875}, 'ratio': {'timing': 1879.2333640662139, 'memory': inf}}
{'subject': '`__le__` (not less than or equals to)', 'one': {'name': '`set`', 'timing': 0.0017304569482803345, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.19077207148075104, 'memory': 0.00390625}, 'ratio': {'timing': 110.24375478993188, 'memory': inf}}
{'subject': '`__lt__`', 'one': {'name': '`set`', 'timing': 0.0020282119512557983, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 1.507423773407936, 'memory': 0.0}, 'ratio': {'timing': 743.227931614638, 'memory': 1.0}}
{'subject': '`__lt__` (not less than)', 'one': {'name': '`set`', 'timing': 0.0017204433679580688, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 1.5027918964624405, 'memory': 0.0}, 'ratio': {'timing': 873.4910572767351, 'memory': 1.0}}
{'subject': '`__ge__`', 'one': {'name': '`set`', 'timing': 0.0018114596605300903, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.0017599314451217651, 'memory': 0.0}, 'ratio': {'timing': 0.971554312507712, 'memory': 1.0}}
{'subject': '`__ge__` (not greater than or equals to)', 'one': {'name': '`set`', 'timing': 0.0017430931329727173, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.0023133456707000732, 'memory': 0.0}, 'ratio': {'timing': 1.3271497815809945, 'memory': 1.0}}
{'subject': '`__gt__`', 'one': {'name': '`set`', 'timing': 0.0017180591821670532, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.014982357621192932, 'memory': 0.00390625}, 'ratio': {'timing': 8.720513109621239, 'memory': inf}}
{'subject': '`__gt__` (not greater than)', 'one': {'name': '`set`', 'timing': 0.0017016828060150146, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 1.505787417292595, 'memory': 0.0}, 'ratio': {'timing': 884.88137270355, 'memory': 1.0}}

## after

{'subject': '`__le__`', 'one': {'name': '`set`', 'timing': 0.0017482638359069824, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.010209798812866211, 'memory': 0.0}, 'ratio': {'timing': 5.839964542634073, 'memory': 1.0}}
{'subject': '`__le__` (not less than or equals to)', 'one': {'name': '`set`', 'timing': 0.001649901270866394, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.0017669647932052612, 'memory': 0.0}, 'ratio': {'timing': 1.0709518347588125, 'memory': 1.0}}
{'subject': '`__lt__`', 'one': {'name': '`set`', 'timing': 0.0019231140613555908, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.009812995791435242, 'memory': 0.0}, 'ratio': {'timing': 5.10265926947574, 'memory': 1.0}}
{'subject': '`__lt__` (not less than)', 'one': {'name': '`set`', 'timing': 0.0016721487045288086, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.0017942637205123901, 'memory': 0.0}, 'ratio': {'timing': 1.0730288015969203, 'memory': 1.0}}
{'subject': '`__ge__`', 'one': {'name': '`set`', 'timing': 0.0016350597143173218, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.0016677379608154297, 'memory': 0.0}, 'ratio': {'timing': 1.019985965168099, 'memory': 1.0}}
{'subject': '`__ge__` (not greater than or equals to)', 'one': {'name': '`set`', 'timing': 0.0016408860683441162, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.0024223923683166504, 'memory': 0.0}, 'ratio': {'timing': 1.476270909388111, 'memory': 1.0}}
{'subject': '`__gt__`', 'one': {'name': '`set`', 'timing': 0.0016394108533859253, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 0.014492392539978027, 'memory': 0.00390625}, 'ratio': {'timing': 8.840000363573564, 'memory': inf}}
{'subject': '`__gt__` (not greater than)', 'one': {'name': '`set`', 'timing': 0.0015995204448699951, 'memory': 0.0}, 'another': {'name': '`sqlitecollections.Set`', 'timing': 1.4936204850673676, 'memory': 0.0}, 'ratio': {'timing': 933.7926813362897, 'memory': 1.0}}
