### PR TITLE
refactor(dict): improve memory efficiency for update

### DIFF
--- a/sqlitecollections/dict.py
+++ b/sqlitecollections/dict.py
@@ -358,7 +358,10 @@ class _Dict(Generic[KT, VT], SqliteCollectionBase[KT], MutableMapping[KT, VT]):
 
     def update(self, __other: Optional[Union[Iterable[Tuple[KT, VT]], Mapping[KT, VT]]] = None, **kwargs: VT) -> None:
         cur = self.connection.cursor()
-        for k, v in chain(dict({} if __other is None else __other).items(), cast(Mapping[KT, VT], kwargs).items()):
+        for k, v in chain(
+            tuple() if __other is None else __other.items() if isinstance(__other, Mapping) else __other,
+            cast(Mapping[KT, VT], kwargs).items(),
+        ):
             self._driver_class.upsert(self.table_name, cur, self.serialize_key(k), self.serialize_value(v))
         self.connection.commit()
 


### PR DESCRIPTION
closes #131 

Improved memory efficiency by avoiding constructing `dict`.

before:
{'subject': '`update` (many)', 'one': {'name': '`dict`', 'timing': 0.04336562752723694, 'memory': 19.30859375}, 'another': {'name': '`sqlitecollections.Dict`', 'timing': 1.3038758337497711, 'memory': 8.0078125}, 'ratio': {'timing': 30.067034840688912, 'memory': 0.414727898037629}}

after:
{'subject': '`update` (many)', 'one': {'name': '`dict`', 'timing': 0.03821238875389099, 'memory': 19.26953125}, 'another': {'name': '`sqlitecollections.Dict`', 'timing': 1.2428984493017197, 'memory': 0.00390625}, 'ratio': {'timing': 32.52605999867415, 'memory': 0.00020271639975674033}}
