### PR TITLE
Feature/issue 232 benchmarking partial execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,5 @@ dmypy.json
 .pyre/
 
 .vscode
+
+temp/

--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -36,59 +36,62 @@ def parse_target(s: str) -> Tuple[str]:
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("--prefix", default="benchmarks")
-    parser.add_argument("--timeout", default=None, type=float)
-    parser.add_argument("--debug", action="store_true")
-    parser.add_argument("targets", nargs="*")
+    subcommand_parser = parser.add_subparsers(dest="subcommand")
+    benchmarking_parser = subcommand_parser.add_parser("benchmarking")
+    benchmarking_parser.add_argument("--prefix", default="benchmarks")
+    benchmarking_parser.add_argument("--timeout", default=None, type=float)
+    benchmarking_parser.add_argument("--debug", action="store_true")
+    benchmarking_parser.add_argument("targets", nargs="*")
     args = parser.parse_args()
-    wd = os.path.dirname(os.path.abspath(__file__))
-    output_dir = os.path.join(os.path.dirname(os.path.dirname(wd)), "benchmark_results", args.prefix)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-    env = Environment(loader=FileSystemLoader(wd), autoescape=select_autoescape())
-    template = env.get_template("template.j2")
+    if args.subcommand == "benchmarking":
+        wd = os.path.dirname(os.path.abspath(__file__))
+        output_dir = os.path.join(os.path.dirname(os.path.dirname(wd)), "benchmark_results", args.prefix)
+        if not os.path.exists(output_dir):
+            os.makedirs(output_dir)
+        env = Environment(loader=FileSystemLoader(wd), autoescape=select_autoescape())
+        template = env.get_template("template.j2")
 
-    for fn in filter(lambda x: x.startswith("benchmark_") and x.endswith(".py"), os.listdir(wd)):
-        container_type_str = re.sub(r"benchmark_([a-z]+)\.py", "\\1", fn)
-        m = importlib.import_module("scbenchmarker.{}".format(re.sub('\\.py$', '', fn)))
-        builtin_base = getattr(
-            m, get_element_by_condition(lambda s: re.match(r"Builtin[A-Za-z]+BenchmarkBase", s), dir(m))
-        )
-        sqlitecollections_base = getattr(
-            m, get_element_by_condition(lambda s: re.match(r"SqliteCollections[A-Za-z]+BenchmarkBase", s), dir(m))
-        )
-        buf = []
-        for benchmark_cls in (
-            getattr(m, cn) for cn in filter(lambda x: re.match(r"^Benchmark.+Base$", x) is not None, dir(m))
-        ):
-            try:
-                builtin_benchmark_class = get_element_by_condition(
-                    lambda x: is_special_benchmark_class(x, builtin_base, benchmark_cls),
-                    (getattr(m, cn) for cn in dir(m)),
-                )
-            except ValueError as _:
-
-                class _(builtin_base, benchmark_cls):
-                    ...
-
-                builtin_benchmark_class = _
-            try:
-                sqlitecollections_benchmark_class = get_element_by_condition(
-                    lambda x: is_special_benchmark_class(x, sqlitecollections_base, benchmark_cls),
-                    (getattr(m, cn) for cn in dir(m)),
-                )
-            except ValueError as _:
-
-                class _(sqlitecollections_base, benchmark_cls):
-                    ...
-
-                sqlitecollections_benchmark_class = _
-            comp = Comparison(
-                builtin_benchmark_class(timeout=args.timeout, debug=args.debug),
-                sqlitecollections_benchmark_class(timeout=args.timeout, debug=args.debug),
+        for fn in filter(lambda x: x.startswith("benchmark_") and x.endswith(".py"), os.listdir(wd)):
+            container_type_str = re.sub(r"benchmark_([a-z]+)\.py", "\\1", fn)
+            m = importlib.import_module("scbenchmarker.{}".format(re.sub('\\.py$', '', fn)))
+            builtin_base = getattr(
+                m, get_element_by_condition(lambda s: re.match(r"Builtin[A-Za-z]+BenchmarkBase", s), dir(m))
             )
-            buf.append(comp().dict())
-            print(".", end="")
-        with open(os.path.join(output_dir, f"{container_type_str}.md"), "w") as fout:
-            fout.write(template.render(data=buf))
-        print("")
+            sqlitecollections_base = getattr(
+                m, get_element_by_condition(lambda s: re.match(r"SqliteCollections[A-Za-z]+BenchmarkBase", s), dir(m))
+            )
+            buf = []
+            for benchmark_cls in (
+                getattr(m, cn) for cn in filter(lambda x: re.match(r"^Benchmark.+Base$", x) is not None, dir(m))
+            ):
+                try:
+                    builtin_benchmark_class = get_element_by_condition(
+                        lambda x: is_special_benchmark_class(x, builtin_base, benchmark_cls),
+                        (getattr(m, cn) for cn in dir(m)),
+                    )
+                except ValueError as _:
+
+                    class _(builtin_base, benchmark_cls):
+                        ...
+
+                    builtin_benchmark_class = _
+                try:
+                    sqlitecollections_benchmark_class = get_element_by_condition(
+                        lambda x: is_special_benchmark_class(x, sqlitecollections_base, benchmark_cls),
+                        (getattr(m, cn) for cn in dir(m)),
+                    )
+                except ValueError as _:
+
+                    class _(sqlitecollections_base, benchmark_cls):
+                        ...
+
+                    sqlitecollections_benchmark_class = _
+                comp = Comparison(
+                    builtin_benchmark_class(timeout=args.timeout, debug=args.debug),
+                    sqlitecollections_benchmark_class(timeout=args.timeout, debug=args.debug),
+                )
+                buf.append(comp().dict())
+                print(".", end="")
+            with open(os.path.join(output_dir, f"{container_type_str}.md"), "w") as fout:
+                fout.write(template.render(data=buf))
+            print("")

--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -40,13 +40,15 @@ def parse_target(s: str) -> Tuple[str]:
 if __name__ == "__main__":
     wd = os.path.dirname(os.path.abspath(__file__))
     parser = ArgumentParser()
+    parser.add_argument("--prefix", default="benchmarks")
     subcommand_parser = parser.add_subparsers(dest="subcommand")
     benchmarking_parser = subcommand_parser.add_parser("benchmarking")
-    benchmarking_parser.add_argument("--prefix", default="benchmarks")
     benchmarking_parser.add_argument("--timeout", default=None, type=float)
     benchmarking_parser.add_argument("--debug", action="store_true")
     benchmarking_parser.add_argument("--output-path")
     benchmarking_parser.add_argument("targets", nargs="*")
+    render_parser = subcommand_parser.add_parser("render")
+    render_parser.add_argument("--input-path")
     args = parser.parse_args()
     if args.subcommand == "benchmarking":
         output_path = args.output_path or os.path.join(
@@ -107,3 +109,7 @@ if __name__ == "__main__":
                 buf[f"{fn}::{comp._subject}"] = comp().dict()
                 print(".", end="")
             print("")
+    elif args.subcommand == "render":
+        ...
+    else:
+        parser.print_help()

--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -3,7 +3,7 @@ import os
 import re
 import sys
 from argparse import ArgumentParser
-from typing import TypeVar
+from typing import Tuple, TypeVar
 
 if sys.version_info >= (3, 9):
     from collections.abc import Callable, Iterable
@@ -28,6 +28,10 @@ def is_special_benchmark_class(x: type, base1: type, base2: type):
         return issubclass(x, base1) and issubclass(x, base2)
     except TypeError as _:
         return False
+
+
+def parse_target(s: str) -> Tuple[str]:
+    return tuple(s.split("::"))
 
 
 if __name__ == "__main__":

--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -39,35 +39,38 @@ def parse_target(s: str) -> Tuple[str]:
 
 if __name__ == "__main__":
     wd = os.path.dirname(os.path.abspath(__file__))
+
     parser = ArgumentParser()
     parser.add_argument("--prefix", default="benchmarks")
+    parser.add_argument("--result-cache")
+
     subcommand_parser = parser.add_subparsers(dest="subcommand")
+
     benchmarking_parser = subcommand_parser.add_parser("benchmarking")
     benchmarking_parser.add_argument("--timeout", default=None, type=float)
     benchmarking_parser.add_argument("--debug", action="store_true")
-    benchmarking_parser.add_argument("--output-path")
+
     benchmarking_parser.add_argument("targets", nargs="*")
+
     render_parser = subcommand_parser.add_parser("render")
-    render_parser.add_argument("--input-path")
+
     args = parser.parse_args()
+
+    cache_path = args.result_cache or os.path.join(
+        os.path.dirname(os.path.dirname(wd)), "temp", f"benchmark_{args.prefix}.db"
+    )
+    cache_dir = os.path.dirname(cache_path)
+
+    cache_dict = sc.Dict[str, dict](
+        connection=cache_path,
+        table_name="benchmark_results",
+        key_serializer=lambda x: x.encode("utf-8"),
+        key_deserializer=lambda x: x.decode("utf-8"),
+        value_serializer=lambda x: json.dumps(x).encode("utf-8"),
+        value_deserializer=lambda x: json.loads(x.decode("utf-8")),
+    )
+
     if args.subcommand == "benchmarking":
-        output_path = args.output_path or os.path.join(
-            os.path.dirname(os.path.dirname(wd)), "temp", f"benchmark_{args.prefix}.db"
-        )
-        output_dir = os.path.dirname(output_path)
-
-        if not os.path.exists(output_dir):
-            os.makedirs(output_dir)
-
-        buf = sc.Dict[str, dict](
-            connection=output_path,
-            table_name="benchmark_results",
-            key_serializer=lambda x: x.encode("utf-8"),
-            key_deserializer=lambda x: x.decode("utf-8"),
-            value_serializer=lambda x: json.dumps(x).encode("utf-8"),
-            value_deserializer=lambda x: json.loads(x.decode("utf-8")),
-        )
-
         for fn in filter(lambda x: x.startswith("benchmark_") and x.endswith(".py"), os.listdir(wd)):
             container_type_str = re.sub(r"benchmark_([a-z]+)\.py", "\\1", fn)
             m = importlib.import_module("scbenchmarker.{}".format(re.sub('\\.py$', '', fn)))
@@ -106,7 +109,7 @@ if __name__ == "__main__":
                     builtin_benchmark_class(timeout=args.timeout, debug=args.debug),
                     sqlitecollections_benchmark_class(timeout=args.timeout, debug=args.debug),
                 )
-                buf[f"{fn}::{comp._subject}"] = comp().dict()
+                cache_dict[f"{fn}::{comp._subject}"] = comp().dict()
                 print(".", end="")
             print("")
     elif args.subcommand == "render":

--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -50,7 +50,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     if args.subcommand == "benchmarking":
         output_path = args.output_path or os.path.join(
-            os.path.dirname(os.path.dirname(os.path.dirname(wd))), "temp", f"benchmark_{args.prefix}.db"
+            os.path.dirname(os.path.dirname(wd)), "temp", f"benchmark_{args.prefix}.db"
         )
         output_dir = os.path.dirname(output_path)
 

--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -35,6 +35,7 @@ if __name__ == "__main__":
     parser.add_argument("--prefix", default="benchmarks")
     parser.add_argument("--timeout", default=None, type=float)
     parser.add_argument("--debug", action="store_true")
+    parser.add_argument("targets", nargs="*")
     args = parser.parse_args()
     wd = os.path.dirname(os.path.abspath(__file__))
     output_dir = os.path.join(os.path.dirname(os.path.dirname(wd)), "benchmark_results", args.prefix)

--- a/tox.ini
+++ b/tox.ini
@@ -43,4 +43,5 @@ commands =
 deps =
     -e ./docs/scbenchmarker
 commands =
-    python -m scbenchmarker --prefix={posargs:{envname}} --timeout=2
+    python -m scbenchmarker --prefix={posargs:{envname}} benchmarking --timeout=2
+    python -m scbenchmarker --prefix={posargs:{envname}} render


### PR DESCRIPTION
# Description

add support for partial exection on the benchmarking.
by adding `[filename]::[testname]`'s as many as you like to `python -m scbenchmarker benchmarking`, benchmarking renews only the result of the tests you specified.

Fixes #232

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
