### PR TITLE
feat(sc): add factories to module top-level attributes

### DIFF
--- a/docs/usage/factory.md
+++ b/docs/usage/factory.md
@@ -33,7 +33,7 @@ With factory:
 
 ```
 import sqlite3
-from sqlitecollections import factory
+import sqlitecollections as sc
 
 conn = sqlite3.connect("path/to/file.db")
 
@@ -43,7 +43,7 @@ def encode(x: str) -> bytes:
 def decode(x: bytes) -> str:
     return x.decode("utf-8")
 
-list_ = factory.ListFactory[str](connection=conn, serializer=encode, deserializer=decode)
+list_ = sc.ListFactory[str](connection=conn, serializer=encode, deserializer=decode)
 
 l1 = list_(["Alice", "Bob", "Carol"])
 l2 = list_(["Dave"])
@@ -56,7 +56,7 @@ If you want to specify table names of containers from a factory, you can do that
 
 ```
 import sqlite3
-from sqlitecollections import factory
+import sqlitecollections as sc
 
 conn = sqlite3.connect("path/to/file.db")
 
@@ -66,7 +66,7 @@ def encode(x: str) -> bytes:
 def decode(x: bytes) -> str:
     return x.decode("utf-8")
 
-list_ = factory.ListFactory[str](connection=conn, serializer=encode, deserializer=decode)
+list_ = sc.ListFactory[str](connection=conn, serializer=encode, deserializer=decode)
 
 l1 = list_["first_table_name"](["Alice", "Bob", "Carol"])
 

--- a/sqlitecollections/__init__.py
+++ b/sqlitecollections/__init__.py
@@ -6,7 +6,8 @@ __package_name__ = "sqlitecollections"
 
 
 from .dict import Dict
+from .factory import DictFactory, ListFactory, SetFactory
 from .list import List
 from .set import Set
 
-__all__ = ["Dict", "List", "Set"]
+__all__ = ["Dict", "List", "Set", "ListFactory", "DictFactory", "SetFactory"]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -6,7 +6,7 @@ from sqlitecollections import factory
 
 
 class ImportFactories(TestCase):
-    def assert_is_factory_class(self, x: object) -> None:
+    def assert_is_factory_class(self, x: type) -> None:
         self.assertTrue(issubclass(x, factory.FactoryBase))
 
     def test_list_factory_is_accessible(self) -> None:

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,34 @@
+from unittest import TestCase
+from xmlrpc.client import Boolean
+
+import sqlitecollections as sc
+from sqlitecollections import factory
+
+
+class ImportFactories(TestCase):
+    def assert_is_factory_class(self, x: object) -> None:
+        self.assertTrue(issubclass(x, factory.FactoryBase))
+
+    def test_list_factory_is_accessible(self) -> None:
+        self.assert_is_factory_class(sc.ListFactory)
+
+    def test_import_list_factory(self) -> None:
+        from sqlitecollections import ListFactory
+
+        self.assert_is_factory_class(ListFactory)
+
+    def test_dict_factory_is_accessible(self) -> None:
+        self.assert_is_factory_class(sc.DictFactory)
+
+    def test_import_dict_factory(self) -> None:
+        from sqlitecollections import DictFactory
+
+        self.assert_is_factory_class(DictFactory)
+
+    def test_set_factory_is_accessible(self) -> None:
+        self.assert_is_factory_class(sc.SetFactory)
+
+    def test_import_set_factory(self) -> None:
+        from sqlitecollections import SetFactory
+
+        self.assert_is_factory_class(SetFactory)


### PR DESCRIPTION
# Description

Add factories to module top-level attributes.

Now, you can access factories like:

```
import sqlitecollections as sc
list_ = sc.ListFactory[str](...)
```

Fixes #241 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
