### PR TITLE
perf(List): improve List.copy's efficiency by using copy SQL.

### DIFF
--- a/sqlitecollections/list.py
+++ b/sqlitecollections/list.py
@@ -222,16 +222,31 @@ class List(SqliteCollectionBase[T], MutableSequence[T]):
         deserializer: Optional[Callable[[bytes], T]] = None,
         persist: bool = True,
     ) -> None:
-        super(List, self).__init__(
-            connection=connection,
-            table_name=table_name,
-            serializer=serializer,
-            deserializer=deserializer,
-            persist=persist,
-        )
-        if __data is not None:
-            self.clear()
-            self.extend(__data)
+        if (
+            isinstance(__data, self.__class__)
+            and __data.connection == connection
+            and __data.serializer == serializer
+            and __data.deserializer == deserializer
+        ):
+            super(List, self).__init__(
+                connection=connection,
+                table_name=table_name,
+                serializer=serializer,
+                deserializer=deserializer,
+                persist=persist,
+                reference_table_name=__data.table_name,
+            )
+        else:
+            super(List, self).__init__(
+                connection=connection,
+                table_name=table_name,
+                serializer=serializer,
+                deserializer=deserializer,
+                persist=persist,
+            )
+            if __data is not None:
+                self.clear()
+                self.extend(__data)
 
     def __delitem__(self, i: Union[int, slice]) -> None:
         cur = self.connection.cursor()


### PR DESCRIPTION
# Description

Improve `List.copy`'s efficiency by using table copy SQL.

Benchmark on my computer:

| before/after | builtin | sqlitecollections | ratio |
| :-- | --: | --: | --: |
| before |	0.0024 | 0.03151 | 13.11788 |
| after | 0.00241 | 0.00803 | 3.32934 |

Fixes #249

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
