### PR TITLE
feat(scbenchmarker): add verbose mode to scbenchmarker

### DIFF
--- a/docs/scbenchmarker/scbenchmarker/__main__.py
+++ b/docs/scbenchmarker/scbenchmarker/__main__.py
@@ -48,6 +48,7 @@ if __name__ == "__main__":
 
     parser = ArgumentParser()
     parser.add_argument("--prefix", default="benchmarks")
+    parser.add_argument("--verbose", action="store_true")
     parser.add_argument("--result-cache")
 
     subcommand_parser = parser.add_subparsers(dest="subcommand")
@@ -122,8 +123,12 @@ if __name__ == "__main__":
                     builtin_benchmark_class(timeout=args.timeout, debug=args.debug),
                     sqlitecollections_benchmark_class(timeout=args.timeout, debug=args.debug),
                 )
-                cache_dict[f"{fn}::{benchmark_name}"] = comp().dict()
-                print(".", end="")
+                res = comp()
+                cache_dict[f"{fn}::{benchmark_name}"] = res.dict()
+                if args.verbose:
+                    print(f"{fn}::{benchmark_name}: {res.dict()}")
+                else:
+                    print(".", end="")
                 printed = True
             if printed:
                 print("")


### PR DESCRIPTION
# Description

Add `verbose` option to `scbenchmarker`'s `__main__` so that developers can see the metrics without rendering the table.

Fixes #253 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
