### PR TITLE
perf(Set): Improved Set.copy and several operations that use copy implicitly

### DIFF
--- a/sqlitecollections/set.py
+++ b/sqlitecollections/set.py
@@ -149,16 +149,31 @@ class Set(SqliteCollectionBase[T], MutableSet[T]):
         deserializer: Optional[Callable[[bytes], T]] = None,
         persist: bool = True,
     ) -> None:
-        super(Set, self).__init__(
-            connection=connection,
-            table_name=table_name,
-            serializer=serializer,
-            deserializer=deserializer,
-            persist=persist,
-        )
-        if __data is not None:
-            self.clear()
-            self.update(__data)
+        if (
+            isinstance(__data, self.__class__)
+            and __data.connection == connection
+            and __data.serializer == serializer
+            and __data.deserializer == deserializer
+        ):
+            super(Set, self).__init__(
+                connection=connection,
+                table_name=table_name,
+                serializer=serializer,
+                deserializer=deserializer,
+                persist=persist,
+                reference_table_name=__data.table_name,
+            )
+        else:
+            super(Set, self).__init__(
+                connection=connection,
+                table_name=table_name,
+                serializer=serializer,
+                deserializer=deserializer,
+                persist=persist,
+            )
+            if __data is not None:
+                self.clear()
+                self.update(__data)
 
     def __contains__(self, value: object) -> bool:
         cur = self.connection.cursor()


### PR DESCRIPTION
# Description

Just improved Set.copy.

Benchmark on my computer:

before/after | builtin | sqlitecollections | ratio
-- | -- | -- | --
before | 0.00295 | 0.01613 | 5.47547
after | 0.00339 | 0.0093 | 2.74503

Some other operations that use Set.copy implicitly were improved, too.

Fixes #250

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
